### PR TITLE
fix: Make snake game more visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -595,7 +595,7 @@
         const snakeCanvas = document.getElementById('snake-canvas');
         const snakeCtx = snakeCanvas.getContext('2d');
         let snakeWidth, snakeHeight;
-        let gridSize = 20;
+        let gridSize = 25;
         let snakeBody = [];
         let food = null;
         let shouldGrow = false;
@@ -608,7 +608,7 @@
         const snakeHeadColor = 'rgba(45, 210, 221, 1)';
         const snakeBodyDecay = 0.85;
         const foodColor = 'rgba(252, 178, 109, 1)';
-        const gridColor = 'rgba(45, 210, 221, 0.03)';
+        const gridColor = 'rgba(45, 210, 221, 0.1)';
 
         // Resize snake canvas
         function resizeSnakeCanvas() {
@@ -684,7 +684,7 @@
                 });
 
                 // Remove tail if not growing
-                if (!shouldGrow && snakeBody.length > 15) {
+                if (!shouldGrow && snakeBody.length > 25) {
                     snakeBody.pop();
                 } else if (shouldGrow) {
                     shouldGrow = false;
@@ -782,8 +782,8 @@
 
         // Snake animation loop
         function animateSnake() {
-            // Clear canvas
-            snakeCtx.fillStyle = 'rgba(23, 23, 23, 0.05)';
+            // Clear canvas with slight fade for trail effect
+            snakeCtx.fillStyle = 'rgba(23, 23, 23, 0.15)';
             snakeCtx.fillRect(0, 0, snakeWidth, snakeHeight);
 
             // Draw grid


### PR DESCRIPTION
- Increase grid opacity from 0.03 to 0.1 (more visible)
- Increase fade opacity from 0.05 to 0.15 (brighter trail)
- Increase grid size from 20 to 25 pixels (larger blocks)
- Increase max snake length from 15 to 25 segments

The snake should now be clearly visible when moving the mouse.