### PR TITLE
fix: Make snake game extremely visible with dark overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
         const snakeCanvas = document.getElementById('snake-canvas');
         const snakeCtx = snakeCanvas.getContext('2d');
         let snakeWidth, snakeHeight;
-        let gridSize = 40;
+        let gridSize = 50;
         let snakeBody = [];
         let food = null;
         let shouldGrow = false;
@@ -605,9 +605,9 @@
 
         // Colors
         const snakeHeadColor = 'rgba(45, 210, 221, 1)';
-        const snakeBodyDecay = 0.95;
+        const snakeBodyDecay = 0.96;
         const foodColor = 'rgba(252, 178, 109, 1)';
-        const gridColor = 'rgba(45, 210, 221, 0.4)';
+        const gridColor = 'rgba(45, 210, 221, 0.8)';
 
         // Resize snake canvas
         function resizeSnakeCanvas() {
@@ -626,7 +626,7 @@
         // Draw grid (visible)
         function drawGrid() {
             snakeCtx.strokeStyle = gridColor;
-            snakeCtx.lineWidth = 1;
+            snakeCtx.lineWidth = 2;
 
             for (let x = 0; x < snakeWidth; x += gridSize) {
                 snakeCtx.beginPath();
@@ -713,22 +713,22 @@
                 if (i === 0) {
                     // Head - very bright cyan
                     snakeCtx.fillStyle = `rgba(45, 210, 221, ${alpha})`;
-                    snakeCtx.shadowBlur = 20;
-                    snakeCtx.shadowColor = 'rgba(45, 210, 221, 0.8)';
+                    snakeCtx.shadowBlur = 30;
+                    snakeCtx.shadowColor = 'rgba(45, 210, 221, 1)';
                 } else {
                     // Body - gradient from cyan to purple
                     const hue = 180 + (i / snakeBody.length) * 60;
-                    snakeCtx.fillStyle = `hsla(${hue}, 90%, 65%, ${alpha})`;
-                    snakeCtx.shadowBlur = 15;
-                    snakeCtx.shadowColor = `hsla(${hue}, 90%, 65%, 0.6)`;
+                    snakeCtx.fillStyle = `hsla(${hue}, 100%, 60%, ${alpha})`;
+                    snakeCtx.shadowBlur = 20;
+                    snakeCtx.shadowColor = `hsla(${hue}, 100%, 60%, 0.8)`;
                 }
 
-                // Draw filled rectangle with glow
+                // Draw filled rectangle with glow (full size)
                 snakeCtx.fillRect(
-                    segment.x * gridSize + 2,
-                    segment.y * gridSize + 2,
-                    gridSize - 4,
-                    gridSize - 4
+                    segment.x * gridSize + 1,
+                    segment.y * gridSize + 1,
+                    gridSize - 2,
+                    gridSize - 2
                 );
 
                 // Reset shadow
@@ -741,17 +741,17 @@
             if (!food) return;
 
             // Pulsing effect
-            const pulse = Math.sin(Date.now() / 300) * 0.3 + 0.7;
+            const pulse = Math.sin(Date.now() / 300) * 0.2 + 0.8;
 
             snakeCtx.fillStyle = `rgba(252, 178, 109, ${pulse})`;
-            snakeCtx.shadowBlur = 25;
-            snakeCtx.shadowColor = 'rgba(252, 178, 109, 0.8)';
+            snakeCtx.shadowBlur = 35;
+            snakeCtx.shadowColor = 'rgba(252, 178, 109, 1)';
 
             snakeCtx.fillRect(
-                food.x * gridSize + 2,
-                food.y * gridSize + 2,
-                gridSize - 4,
-                gridSize - 4
+                food.x * gridSize + 1,
+                food.y * gridSize + 1,
+                gridSize - 2,
+                gridSize - 2
             );
 
             // Reset shadow
@@ -760,8 +760,9 @@
 
         // Snake animation loop
         function animateSnake() {
-            // Clear canvas completely (no fade, full visibility)
-            snakeCtx.clearRect(0, 0, snakeWidth, snakeHeight);
+            // Fill with semi-transparent dark background to make snake visible
+            snakeCtx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+            snakeCtx.fillRect(0, 0, snakeWidth, snakeHeight);
 
             // Draw grid
             drawGrid();


### PR DESCRIPTION
Critical visibility improvements:
- Add semi-transparent black background (rgba 0,0,0,0.5) to snake canvas
- This creates a visible dark overlay over entire screen
- Grid size increased from 40px to 50px (larger blocks)
- Grid opacity doubled from 0.4 to 0.8 (very bright lines)
- Grid line width increased from 1px to 2px (thicker)
- Body decay slowed from 0.95 to 0.96 (longer trail)

Snake glow enhancements:
- Head shadow blur increased from 20px to 30px
- Head shadow is now fully opaque (alpha 1.0)
- Body shadow blur increased from 15px to 20px
- Body saturation increased to 100% (maximum color)
- Block padding reduced from 2px to 1px (larger blocks)

Food improvements:
- Shadow blur increased from 25px to 35px
- Shadow is now fully opaque
- Pulse range changed to 0.8-1.0 (brighter minimum)

Now the snake canvas creates a visible dark overlay with bright glowing grid and blocks that are impossible to miss!