### PR TITLE
fix: Increase background opacity from 0.5 to 0.85 for maximum visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -760,8 +760,8 @@
 
         // Snake animation loop
         function animateSnake() {
-            // Fill with semi-transparent dark background to make snake visible
-            snakeCtx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+            // Fill with SOLID black background to make snake EXTREMELY visible
+            snakeCtx.fillStyle = 'rgba(0, 0, 0, 0.85)';
             snakeCtx.fillRect(0, 0, snakeWidth, snakeHeight);
 
             // Draw grid


### PR DESCRIPTION
Make the dark overlay almost completely opaque (85% instead of 50%) so the bright grid and glowing snake blocks are impossible to miss